### PR TITLE
feat: color blind safe palette for GTDB plots

### DIFF
--- a/gtdb_release_tk/VERSION
+++ b/gtdb_release_tk/VERSION
@@ -1,3 +1,6 @@
+0.0.9
+- updated to color blind safe palette for GTDB stat figures
+
 0.0.8
 - updated method for selecting representative genomes at each taxonomic rank
 

--- a/gtdb_release_tk/plots/genome_category_per_rank.py
+++ b/gtdb_release_tk/plots/genome_category_per_rank.py
@@ -31,6 +31,7 @@ from matplotlib import gridspec
 from gtdb_release_tk.common import (ENV_CATEGORIES,
                                     sp_cluster_type_category)
 from gtdb_release_tk.taxon_utils import canonical_taxon
+from gtdb_release_tk.plots.palette import COLOR_BLIND_PALETTE
 
 
 class GenomeCateogryPerRankPlot(AbstractPlot):
@@ -58,9 +59,9 @@ class GenomeCateogryPerRankPlot(AbstractPlot):
         isolate = np_array(isolate)
         env = np_array(env)
 
-        p1 = axis.bar(ind, both, width, color='#80b1d3')
-        p2 = axis.bar(ind, isolate, width, bottom=both, color='#fdae6b')
-        p3 = axis.bar(ind, env, width, bottom=both+isolate, color='#b3de69')
+        p1 = axis.bar(ind, both, width, color=COLOR_BLIND_PALETTE.grey)
+        p2 = axis.bar(ind, isolate, width, bottom=both, color=COLOR_BLIND_PALETTE.orange)
+        p3 = axis.bar(ind, env, width, bottom=both+isolate, color=COLOR_BLIND_PALETTE.blue)
 
         axis.set_ylim([0, 100])
         axis.set_yticks(range(0, 101, 10))
@@ -141,7 +142,8 @@ class GenomeCategoryPerRank(object):
                     gtdb_taxa = [t.strip() for t in taxonomy.split(';')]
                     gtdb_taxonomy[gid] = gtdb_taxa
 
-                    sp_clusters[gtdb_taxa[6]].add(gid)
+                    sp = gtdb_taxa[6]
+                    sp_clusters[sp].add(gid)
 
                     genome_category[gid] = line_split[genome_category_index]
 
@@ -154,7 +156,7 @@ class GenomeCategoryPerRank(object):
         for sp, gids in sp_clusters.items():
             sp_genome_types[sp] = sp_cluster_type_category(
                 gids, genome_category)
-
+            
         # get species in each taxa
         sp_in_taxa = defaultdict(lambda: defaultdict(set))
         for taxa in gtdb_taxonomy.values():

--- a/gtdb_release_tk/plots/genome_quality.py
+++ b/gtdb_release_tk/plots/genome_quality.py
@@ -24,24 +24,17 @@ __maintainer__ = 'Donovan Parks'
 __email__ = 'donovan.parks@gmail.com'
 __status__ = 'Development'
 
-import os
-import sys
+
 import logging
-import argparse
-import ntpath
-import csv
-import random
-import operator
 from pathlib import PurePath
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 
 from biolib.plots.abstract_plot import AbstractPlot
-
-from numpy import sum as np_sum
-                    
+                   
 from matplotlib.ticker import NullFormatter
-from matplotlib import collections
 import matplotlib.lines as mlines
+
+from gtdb_release_tk.plots.palette import COLOR_BLIND_PALETTE
 
 
 class GenomeQualityPlot(AbstractPlot):
@@ -96,23 +89,20 @@ class GenomeQualityPlot(AbstractPlot):
         p_x = []
         p_y = []
         p_c = []
-        colors = [(237/255.0,102/255.0,93/255.0),
-                (166/255.0,206/255.0,227/255.0),
-                (127/255.0,127/255.0,127/255.0)]
-        
+
         for cur_comp, cur_cont, category in zip(comp, cont, mimag_category):
             if category == 'hq':
                 hq_x.append(cur_comp)
                 hq_y.append(cur_cont)
-                hq_c.append(colors[0])
+                hq_c.append(COLOR_BLIND_PALETTE.orange)
             elif category == 'mq':
                 mq_x.append(cur_comp)
                 mq_y.append(cur_cont)
-                mq_c.append(colors[1])
+                mq_c.append(COLOR_BLIND_PALETTE.blue)
             elif category == 'lq':
                 p_x.append(cur_comp)
                 p_y.append(cur_cont)
-                p_c.append(colors[2])
+                p_c.append(COLOR_BLIND_PALETTE.grey)
             else:
                 assert(False)
 
@@ -172,10 +162,10 @@ class GenomeQualityPlot(AbstractPlot):
     
         # plot top histogram
         axes_top_histogram.xaxis.set_major_formatter(NullFormatter())
-        pdf, bins, patches = axes_top_histogram.hist(x, 
+        pdf, _bins, _patches = axes_top_histogram.hist(x, 
                                                     bins=num_bins, 
                                                     weights=weights,
-                                                    color=colors[::-1],
+                                                    color=[COLOR_BLIND_PALETTE.grey, COLOR_BLIND_PALETTE.orange, COLOR_BLIND_PALETTE.blue],
                                                     edgecolor=(0.2,0.2,0.2),
                                                     lw=0.5, 
                                                     histtype='bar',
@@ -195,11 +185,11 @@ class GenomeQualityPlot(AbstractPlot):
         # plot right histogram
         y = [p_y, mq_y, hq_y]
         axes_right_histogram.yaxis.set_major_formatter(NullFormatter())
-        pdf, bins, patches = axes_right_histogram.hist(y, 
+        pdf, _bins, _patches = axes_right_histogram.hist(y, 
                                                         bins=num_bins, 
                                                         orientation='horizontal',
                                                         weights=weights,
-                                                        color=colors[::-1],
+                                                        color=[COLOR_BLIND_PALETTE.grey, COLOR_BLIND_PALETTE.orange, COLOR_BLIND_PALETTE.blue],
                                                         edgecolor=(0.2,0.2,0.2),
                                                         lw=0.5, 
                                                         histtype='bar',

--- a/gtdb_release_tk/plots/genomic_stats.py
+++ b/gtdb_release_tk/plots/genomic_stats.py
@@ -35,15 +35,12 @@ from numpy import (median as np_median,
                     mean as np_mean,
                     std as np_std,
                     percentile as np_percentile,
-                    arange as np_arange,
-                    array as np_array,
-                    ones_like as np_ones_like,
-                    bincount as np_bincount)
+                    ones_like as np_ones_like)
                     
 from matplotlib.ticker import FuncFormatter, MaxNLocator
-from matplotlib.offsetbox import AnchoredText
 
 import gtdb_release_tk.HTML as HTML
+
 
 class GenomicStatsPlot(AbstractPlot):
     """Create histogram of common genomic statistics."""
@@ -156,7 +153,7 @@ class GenomicStats(object):
                 gtdb_taxonomy_index = header.index('gtdb_taxonomy')
                 ncbi_taxonomy_index = header.index('ncbi_taxonomy')
                 gtdb_rep_index = header.index('gtdb_representative')
-                gtdb_type_index = header.index('gtdb_type_designation')
+                gtdb_type_index = header.index('gtdb_type_designation_ncbi_taxa')
                     
                 for line in f:
                     line_split = line.strip().split('\t')

--- a/gtdb_release_tk/plots/ncbi_compare.py
+++ b/gtdb_release_tk/plots/ncbi_compare.py
@@ -15,17 +15,17 @@
 #                                                                             #
 ###############################################################################
 
-import os
-import sys
 import logging
 from pathlib import PurePath
-from collections import defaultdict
 
 from biolib.taxonomy import Taxonomy
 from biolib.plots.abstract_plot import AbstractPlot
 
 from numpy import (arange as np_arange,
                     array as np_array)
+
+from gtdb_release_tk.plots.palette import COLOR_BLIND_PALETTE
+
 
 class NCBI_ComparePlot(AbstractPlot):
     """Box and whisker plot."""
@@ -48,9 +48,9 @@ class NCBI_ComparePlot(AbstractPlot):
         passive = np_array(passive)
         active = np_array(active)
 
-        p1 = axis.bar(ind, unchanged, width, color='#80b1d3')
-        p2 = axis.bar(ind, passive, width, bottom=unchanged, color='#fdae6b')
-        p3 = axis.bar(ind, active, width, bottom=unchanged+passive, color='#b3de69')
+        p1 = axis.bar(ind, unchanged, width, color=COLOR_BLIND_PALETTE.grey)
+        p2 = axis.bar(ind, passive, width, bottom=unchanged, color=COLOR_BLIND_PALETTE.orange)
+        p3 = axis.bar(ind, active, width, bottom=unchanged+passive, color=COLOR_BLIND_PALETTE.blue)
 
         axis.set_ylim([0, 100])
         axis.set_yticks(range(0, 101, 10))

--- a/gtdb_release_tk/plots/nomenclatural_per_rank.py
+++ b/gtdb_release_tk/plots/nomenclatural_per_rank.py
@@ -25,6 +25,8 @@ from biolib.plots.abstract_plot import AbstractPlot
 from numpy import (arange as np_arange,
                    array as np_array)
 
+from gtdb_release_tk.plots.palette import COLOR_BLIND_PALETTE
+
 
 class NomenclaturalPerRankPlot(AbstractPlot):
     """Box and whisker plot."""
@@ -46,9 +48,9 @@ class NomenclaturalPerRankPlot(AbstractPlot):
         plot_latinized = np_array(plot_latinized)
         plot_placeholder = np_array(plot_placeholder)
 
-        p1 = axis.bar(ind, plot_latinized, width, color='#80b1d3')
+        p1 = axis.bar(ind, plot_latinized, width, color=COLOR_BLIND_PALETTE.orange)
         p2 = axis.bar(ind, plot_placeholder, width,
-                      bottom=plot_latinized, color='#fdae6b')
+                      bottom=plot_latinized, color=COLOR_BLIND_PALETTE.blue)
 
         axis.set_ylim([0, 100])
         axis.set_yticks(range(0, 101, 10))

--- a/gtdb_release_tk/plots/palette.py
+++ b/gtdb_release_tk/plots/palette.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+@dataclass
+
+class Palette:
+    grey: str
+    orange: str
+    blue: str
+
+
+COLOR_BLIND_PALETTE = Palette('#ABABAB', '#FFBC79', '#5F9ED1')

--- a/gtdb_release_tk/plots/species_rep_type.py
+++ b/gtdb_release_tk/plots/species_rep_type.py
@@ -20,13 +20,9 @@ import logging
 from pathlib import PurePath
 from collections import defaultdict
 
-from biolib.taxonomy import Taxonomy
 from biolib.plots.abstract_plot import AbstractPlot
-
-from numpy import (arange as np_arange,
-                    array as np_array)
                     
-from gtdb_release_tk.common import ENV_CATEGORIES
+from gtdb_release_tk.plots.palette import COLOR_BLIND_PALETTE
 
 
 class SpeciesRepTypePlot(AbstractPlot):
@@ -52,13 +48,13 @@ class SpeciesRepTypePlot(AbstractPlot):
         colors = []
         for c in [type_strain_categories, latinized_categories, placeholder_categories]:
             sizes.append(c.get('ISOLATE', 0))
-            colors.append('#fdae6b')
+            colors.append(COLOR_BLIND_PALETTE.orange)
             
             sizes.append(c.get('MAG', 0))
-            colors.append('#b3de69')
+            colors.append(COLOR_BLIND_PALETTE.blue)
             
             sizes.append(c.get('SAG', 0))
-            colors.append('#80b1d3')
+            colors.append(COLOR_BLIND_PALETTE.grey)
             
 
         wedgeprops = {'linewidth': 1, 
@@ -161,7 +157,7 @@ class SpeciesRepType(object):
                 header = f.readline().strip().split('\t')
                 
                 gtdb_taxonomy_index = header.index('gtdb_taxonomy')
-                gtdb_type_index = header.index('gtdb_type_designation')
+                gtdb_type_index = header.index('gtdb_type_designation_ncbi_taxa')
                 gtdb_rep_index = header.index('gtdb_representative')
                 gtdb_genome_rep_index = header.index('gtdb_genome_representative')
                 genome_category_index = header.index('ncbi_genome_category')


### PR DESCRIPTION
- cross hatching in Matplotlib is complicated and cross hatching doesn't look good in all plot types
- a color blind safe palette based on the Tableau Color Blind 10 palette has been adopted
- factored out colors into palette.py to ensure easy modification and consistency in plots
- bumped version to 0.0.9